### PR TITLE
feat(slicing): Improve slicing 🔪

### DIFF
--- a/Documentation~/manual/getting-started.md
+++ b/Documentation~/manual/getting-started.md
@@ -15,8 +15,11 @@ Options for controlling prefab generation.
 
 The texture settings Unity will use for Texture import. See [Unity Docs: Texture Import Settings](https://docs.unity3d.com/Manual/class-TextureImporter.html)
 
+- `sliceOptions` - Extension to the default set, used to control Spritesheet dimension data, in the event you are importing a spritesheet. Leaving as default (`0`s) will import as one sprite per layer. Slicing will import as multiple sprites per layer.
+
 ### Rig Options
 
 Options for controlling animation and rigging generation.
 
+- `Create Rig` - If disabled, no rig (animations, avatars, etc) will be created. 
 - `loopTags` - Controls which frame tags from the aseprite file will import as looping animations. By default, all animations are non-looping.

--- a/Editor/AsepriteImporter.cs
+++ b/Editor/AsepriteImporter.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace FasterGames.Aseprite.Editor
 {
-    [ScriptedImporter(version: 2, new []{"ase", "aseprite"})]
+    [ScriptedImporter(version: 3, new []{"ase", "aseprite"})]
     public class AsepriteImporter : ScriptedImporter
     {
         public PrefabImporter.UserOptions prefabOptions = new PrefabImporter.UserOptions();
@@ -47,6 +47,18 @@ namespace FasterGames.Aseprite.Editor
 
             var spritesByLayer = textureImporter.ImportAsset(ctx);
 
+            // map in the layer default sprites
+            for (var layerIndex = 0; layerIndex < layerChunks.Count; layerIndex++)
+            {
+                var layer = layerChunks[layerIndex];
+                var layerName = layer.LayerName;
+
+                var layerObject = rootPrefab.transform.Find(layerName);
+                var layerSprite = layerObject.GetComponent<SpriteRenderer>();
+                
+                layerSprite.sprite = spritesByLayer[layerName][0];
+            }
+            
             var rigImporter = new AnimationRigImporter(file, new AnimationRigImporter.Options()
             {
                 userOptions = rigOptions,

--- a/Editor/Importers/AnimationRigImporter.cs
+++ b/Editor/Importers/AnimationRigImporter.cs
@@ -15,6 +15,7 @@ namespace FasterGames.Aseprite.Editor.Importers
         [Serializable]
         public class UserOptions
         {
+            public bool createRig = true;
             public List<string> loopTags = new List<string>();
         }
         
@@ -41,21 +42,13 @@ namespace FasterGames.Aseprite.Editor.Importers
 
         public override Result ImportAsset(AssetImportContext ctx)
         {
+            // nothing to do
+            if (!m_Options.userOptions.createRig)
+                return null;
+            
             // get the layers, for future use
             var layerChunks = Source.GetChunks<LayerChunk>();
-            
-            // create the layer objects
-            for (var layerIndex = 0; layerIndex < layerChunks.Count; layerIndex++)
-            {
-                var layer = layerChunks[layerIndex];
-                var layerName = layer.LayerName;
 
-                var layerObject = m_Options.rootObject.transform.Find(layerName);
-                var layerSprite = layerObject.GetComponent<SpriteRenderer>();
-                
-                layerSprite.sprite = m_Options.spritesByLayerName[layerName][0];
-            }
-            
             // create the avatar
             var rootAvatar = AvatarBuilder.BuildGenericAvatar(m_Options.rootObject, m_Options.rootObject.name);
             rootAvatar.name = AsepriteMetadata.FormatName(ctx.assetPath, null, null);


### PR DESCRIPTION
Improves the slicing capabilities such that spritesheets can also be brought in per layer, rather than limiting the user to a single sprite per layer. This can helpful if you have a tilemap you want to bring in, even if it's only on 1 layer in aseprite.

Also add an option to disable rig generation, again not something that feels needed for tilemaps. 